### PR TITLE
fix: add support for legacy mode

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -125,14 +125,20 @@ export class RedisAdapter extends Adapter {
 
     const isRedisV4 = typeof this.pubClient.pSubscribe === "function";
     if (isRedisV4) {
-      this.subClient.pSubscribe(
+      let client = this.subClient;
+      try {
+        this.subClient.v4.hSet;
+        client = client.v4;
+      } catch (e) {}
+
+      client.pSubscribe(
         this.channel + "*",
         (msg, channel) => {
           this.onmessage(null, channel, msg);
         },
         true
       );
-      this.subClient.subscribe(
+      client.subscribe(
         [this.requestChannel, this.responseChannel, specificResponseChannel],
         (msg, channel) => {
           this.onrequest(channel, msg);


### PR DESCRIPTION
The latest release checks for Redis v4 but doesn't check if the
user enabled legacyMode. If legacyMode is enabled, subscribe functions
are causing errors.

Unfortunately the Redis client API currently doesn't offer any way to
check if legacy mode is enabled which is the reason why it I have to
check it in this hacky way.