### PR TITLE
Update notepack.io to ~3.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@socket.io/redis-adapter",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@socket.io/redis-adapter",
-      "version": "7.1.0",
+      "version": "7.2.0",
       "license": "MIT",
       "dependencies": {
         "debug": "~4.3.1",
-        "notepack.io": "~2.2.0",
+        "notepack.io": "~3.0.1",
         "socket.io-adapter": "^2.4.0",
         "uid2": "0.0.3"
       },
@@ -1629,9 +1629,9 @@
       }
     },
     "node_modules/notepack.io": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-2.2.0.tgz",
-      "integrity": "sha512-9b5w3t5VSH6ZPosoYnyDONnUTF8o0UkBw7JLA6eBlYJWyGT1Q3vQa8Hmuj1/X6RYvHjjygBDgw6fJhe0JEojfw=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-3.0.1.tgz",
+      "integrity": "sha512-TKC/8zH5pXIAMVQio2TvVDTtPRX+DJPHDqjRbxogtFiByHyzKmy96RA0JtCQJ+WouyyL4A10xomQzgbUT+1jCg=="
     },
     "node_modules/nyc": {
       "version": "15.1.0",
@@ -3819,9 +3819,9 @@
       }
     },
     "notepack.io": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-2.2.0.tgz",
-      "integrity": "sha512-9b5w3t5VSH6ZPosoYnyDONnUTF8o0UkBw7JLA6eBlYJWyGT1Q3vQa8Hmuj1/X6RYvHjjygBDgw6fJhe0JEojfw=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-3.0.1.tgz",
+      "integrity": "sha512-TKC/8zH5pXIAMVQio2TvVDTtPRX+DJPHDqjRbxogtFiByHyzKmy96RA0JtCQJ+WouyyL4A10xomQzgbUT+1jCg=="
     },
     "nyc": {
       "version": "15.1.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "debug": "~4.3.1",
-    "notepack.io": "~2.2.0",
+    "notepack.io": "~3.0.1",
     "socket.io-adapter": "^2.4.0",
     "uid2": "0.0.3"
   },


### PR DESCRIPTION
This is a follow-up to https://github.com/socketio/socket.io-redis-emitter/pull/113

I found out that the way `Date` instances are serialized changes from notepack.io 2 to 3, so after upgrading `socket.io-redis-emitter`, Dates get decoded as eg. `[ -1, <Buffer 90 b8 57 00 63 37 5d 19> ]`. Seems like the library version needs to be kept in sync.

CC @darrachequesne 🤗 