### PR TITLE
Update uid2 dependency from 0.0.3 to 1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "debug": "~4.3.1",
         "notepack.io": "~2.2.0",
         "socket.io-adapter": "^2.4.0",
-        "uid2": "0.0.3"
+        "uid2": "1.0.0"
       },
       "devDependencies": {
         "@types/expect.js": "^0.3.29",
@@ -2322,9 +2322,12 @@
       }
     },
     "node_modules/uid2": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
-      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-1.0.0.tgz",
+      "integrity": "sha512-+I6aJUv63YAcY9n4mQreLUt0d4lvwkkopDNmpomkAUz0fAkEMV9pRWxN0EjhW1YfRhcuyHg2v3mwddCDW1+LFQ==",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
     },
     "node_modules/uuid": {
       "version": "3.4.0",
@@ -4360,9 +4363,9 @@
       "dev": true
     },
     "uid2": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
-      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-1.0.0.tgz",
+      "integrity": "sha512-+I6aJUv63YAcY9n4mQreLUt0d4lvwkkopDNmpomkAUz0fAkEMV9pRWxN0EjhW1YfRhcuyHg2v3mwddCDW1+LFQ=="
     },
     "uuid": {
       "version": "3.4.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "debug": "~4.3.1",
     "notepack.io": "~2.2.0",
     "socket.io-adapter": "^2.4.0",
-    "uid2": "0.0.3"
+    "uid2": "1.0.0"
   },
   "devDependencies": {
     "@types/expect.js": "^0.3.29",


### PR DESCRIPTION
This updates the [`uid2`](https://www.npmjs.com/package/uid2) dependency from 0.0.3 to 1.0.0 (its latest release) which has the following changes (see its [HISTORY.md](https://github.com/coreh/uid2/blob/master/HISTORY.md) for full details):
* Uses `crypto.randomBytes` instead of `crypto.pseudoRandomBytes` https://github.com/coreh/uid2/commit/e492a9db2a9892dc13a5f55e4ae28ff9af2add64
* Adds `-_` to generated unique IDs https://github.com/coreh/uid2/commit/a3b8def77e211a7fd8f244666a0e1d3edacf0d16
* Improves generation time of an ID by 15% https://github.com/coreh/uid2/commit/3cfd2cc9555b772f3e361ca60a98c0931d504b41

The first change would only matter to clients that are using a version of node < 4.0.0, but this repo only supports >= 10 so that's not really a problem. This does also future-proof this repo a bit where while the `crypto.pseudoRandomBytes` does work, it's undocumented in the [`crypto` docs](https://nodejs.org/api/crypto.html), as `crypto.randomBytes` should work essentially the same, unless you ran it exactly at system boot time, in which it'll then block execution till enough entropy has built up.

The second case could matter if someone was for some reason relying on the exact shape of the generated IDs, but that seems unlikely, and the internal code doesn't have any issues with the two additional characters.