### PR TITLE
Add option to allow usage of custom parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ The following options are allowed:
 
 - `key`: the name of the key to pub/sub events on as prefix (`socket.io`)
 - `requestsTimeout`: optional, after this timeout the adapter will stop waiting from responses to request (`5000ms`)
+- `parser`: optional, parser to use for encoding and decoding messages passed through Redis ([`notepack.io`](https://www.npmjs.com/package/notepack.io))
 
 ### RedisAdapter
 
@@ -205,6 +206,7 @@ that a regular `Adapter` does not
 - `pubClient`
 - `subClient`
 - `requestsTimeout`
+- `parser`
 
 ### RedisAdapter#sockets(rooms: Set&lt;String&gt;)
 


### PR DESCRIPTION
Closes #469 

This PR adds a new `parser` option to the adapter constructor to allow setting a custom parser to use, defaulting to using `notepack.io`. This would allow someone to use a different msgpack library if they wanted, or even an entirely different protocol altogether (e.g. protobuf).

I looked into writing tests for this, but wasn't sure what the best way to incorporate them. Would you want me to modify the setup in `index.ts` or add a second test file `custom-parser.ts`?