### PR TITLE
Implement adapter.close function

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -102,8 +102,10 @@ export class RedisAdapter extends Adapter {
   private readonly channel: string;
   private readonly requestChannel: string;
   private readonly responseChannel: string;
+  private readonly specificResponseChannel: string;
   private requests: Map<string, Request> = new Map();
   private ackRequests: Map<string, AckRequest> = new Map();
+  private redisListeners: Map<string, Function> = new Map();
 
   /**
    * Adapter constructor.
@@ -133,34 +135,51 @@ export class RedisAdapter extends Adapter {
     this.channel = prefix + "#" + nsp.name + "#";
     this.requestChannel = prefix + "-request#" + this.nsp.name + "#";
     this.responseChannel = prefix + "-response#" + this.nsp.name + "#";
-    const specificResponseChannel = this.responseChannel + this.uid + "#";
+    this.specificResponseChannel = this.responseChannel + this.uid + "#";
 
     const isRedisV4 = typeof this.pubClient.pSubscribe === "function";
     if (isRedisV4) {
+      this.redisListeners.set("psub", (msg, channel) => {
+        this.onmessage(null, channel, msg);
+      });
+
+      this.redisListeners.set("sub", (msg, channel) => {
+        this.onrequest(channel, msg);
+      });
+
       this.subClient.pSubscribe(
         this.channel + "*",
-        (msg, channel) => {
-          this.onmessage(null, channel, msg);
-        },
+        this.redisListeners.get("psub"),
         true
       );
       this.subClient.subscribe(
-        [this.requestChannel, this.responseChannel, specificResponseChannel],
-        (msg, channel) => {
-          this.onrequest(channel, msg);
-        },
+        [
+          this.requestChannel,
+          this.responseChannel,
+          this.specificResponseChannel,
+        ],
+        this.redisListeners.get("sub"),
         true
       );
     } else {
+      this.redisListeners.set("pmessageBuffer", this.onmessage.bind(this));
+      this.redisListeners.set("messageBuffer", this.onrequest.bind(this));
+
       this.subClient.psubscribe(this.channel + "*");
-      this.subClient.on("pmessageBuffer", this.onmessage.bind(this));
+      this.subClient.on(
+        "pmessageBuffer",
+        this.redisListeners.get("pmessageBuffer")
+      );
 
       this.subClient.subscribe([
         this.requestChannel,
         this.responseChannel,
-        specificResponseChannel,
+        this.specificResponseChannel,
       ]);
-      this.subClient.on("messageBuffer", this.onrequest.bind(this));
+      this.subClient.on(
+        "messageBuffer",
+        this.redisListeners.get("messageBuffer")
+      );
     }
 
     const registerFriendlyErrorHandler = (redisClient) => {
@@ -916,5 +935,50 @@ export class RedisAdapter extends Adapter {
 
   serverCount(): Promise<number> {
     return this.getNumSub();
+  }
+
+  close(): Promise<void> | void {
+    const isRedisV4 = typeof this.pubClient.pSubscribe === "function";
+    if (isRedisV4) {
+      this.subClient.pUnsubscribe(
+        this.channel + "*",
+        this.redisListeners.get("psub"),
+        true
+      );
+
+      // There is a bug in redis v4 when unsubscribing multiple channels at once, so we'll unsub one at a time.
+      // See https://github.com/redis/node-redis/issues/2052
+      this.subClient.unsubscribe(
+        this.requestChannel,
+        this.redisListeners.get("sub"),
+        true
+      );
+      this.subClient.unsubscribe(
+        this.responseChannel,
+        this.redisListeners.get("sub"),
+        true
+      );
+      this.subClient.unsubscribe(
+        this.specificResponseChannel,
+        this.redisListeners.get("sub"),
+        true
+      );
+    } else {
+      this.subClient.punsubscribe(this.channel + "*");
+      this.subClient.off(
+        "pmessageBuffer",
+        this.redisListeners.get("pmessageBuffer")
+      );
+
+      this.subClient.unsubscribe([
+        this.requestChannel,
+        this.responseChannel,
+        this.specificResponseChannel,
+      ]);
+      this.subClient.off(
+        "messageBuffer",
+        this.redisListeners.get("messageBuffer")
+      );
+    }
   }
 }

--- a/test/index.ts
+++ b/test/index.ts
@@ -231,20 +231,20 @@ describe(`socket.io-redis with ${
 
     return new Promise(async (resolve, reject) => {
       // Give it a moment to subscribe to all the channels
-      setTimeout(async() => {
-        try {               
+      setTimeout(async () => {
+        try {
           const info = await getInfo();
-  
+
           expect(info.pubsub_patterns).to.eql(3); // 1 pattern for each namespace
           expect(info.pubsub_channels).to.eql(5); // 2 shared (request/response) + 3 unique for each namespace
-  
+
           namespace1.adapter.close();
-  
+
           // Give it a moment to unsubscribe
           setTimeout(async () => {
             try {
               const info = await getInfo();
-  
+
               expect(info.pubsub_patterns).to.eql(2); // 1 less pattern
               expect(info.pubsub_channels).to.eql(4); // 1 less sub
               resolve();
@@ -254,8 +254,8 @@ describe(`socket.io-redis with ${
           }, 200);
         } catch (error) {
           reject(error);
-        }    
-      }, 300);      
+        }
+      }, 300);
     });
   });
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -193,66 +193,69 @@ describe(`socket.io-redis with ${
   });
 
   it("unsubscribes when close is called", async () => {
-    return new Promise(async (resolve, reject) => {
-      try {
-        const parseInfo = (rawInfo: string) => {
-          const info = {};
+    const parseInfo = (rawInfo: string) => {
+      const info = {};
 
-          rawInfo.split("\r\n").forEach((line) => {
-            if (line.length > 0 && !line.startsWith("#")) {
-              const fieldVal = line.split(":");
-              info[fieldVal[0]] = fieldVal[1];
+      rawInfo.split("\r\n").forEach((line) => {
+        if (line.length > 0 && !line.startsWith("#")) {
+          const fieldVal = line.split(":");
+          info[fieldVal[0]] = fieldVal[1];
+        }
+      });
+
+      return info;
+    };
+
+    const getInfo = async (): Promise<any> => {
+      if (process.env.REDIS_CLIENT === undefined) {
+        return parseInfo(
+          await namespace3.adapter.pubClient.sendCommand(["info"])
+        );
+      } else if (process.env.REDIS_CLIENT === "ioredis") {
+        return parseInfo(await namespace3.adapter.pubClient.call("info"));
+      } else {
+        return await new Promise((resolve, reject) => {
+          namespace3.adapter.pubClient.sendCommand(
+            "info",
+            [],
+            (err, result) => {
+              if (err) {
+                reject(err);
+              }
+              resolve(parseInfo(result));
             }
-          });
-
-          return info;
-        };
-
-        const getInfo = async (): Promise<any> => {
-          if (process.env.REDIS_CLIENT === undefined) {
-            return parseInfo(
-              await namespace3.adapter.pubClient.sendCommand(["info"])
-            );
-          } else if (process.env.REDIS_CLIENT === "ioredis") {
-            return parseInfo(await namespace3.adapter.pubClient.call("info"));
-          } else {
-            return await new Promise((resolve, reject) => {
-              namespace3.adapter.pubClient.sendCommand(
-                "info",
-                [],
-                (err, result) => {
-                  if (err) {
-                    reject(err);
-                  }
-                  resolve(parseInfo(result));
-                }
-              );
-            });
-          }
-        };
-
-        const info = await getInfo();
-
-        expect(info.pubsub_patterns).to.eql(3); // 1 pattern for each namespace
-        expect(info.pubsub_channels).to.eql(5); // 2 shared (request/response) + 3 unique for each namespace
-
-        namespace1.adapter.close();
-
-        // Give it a moment to unsubscribe
-        setTimeout(async () => {
-          try {
-            const info = await getInfo();
-
-            expect(info.pubsub_patterns).to.eql(2); // 1 less pattern
-            expect(info.pubsub_channels).to.eql(4); // 1 less sub
-            resolve();
-          } catch (error) {
-            reject(error);
-          }
-        }, 200);
-      } catch (error) {
-        reject(error);
+          );
+        });
       }
+    };
+
+    return new Promise(async (resolve, reject) => {
+      // Give it a moment to subscribe to all the channels
+      setTimeout(async() => {
+        try {               
+          const info = await getInfo();
+  
+          expect(info.pubsub_patterns).to.eql(3); // 1 pattern for each namespace
+          expect(info.pubsub_channels).to.eql(5); // 2 shared (request/response) + 3 unique for each namespace
+  
+          namespace1.adapter.close();
+  
+          // Give it a moment to unsubscribe
+          setTimeout(async () => {
+            try {
+              const info = await getInfo();
+  
+              expect(info.pubsub_patterns).to.eql(2); // 1 less pattern
+              expect(info.pubsub_channels).to.eql(4); // 1 less sub
+              resolve();
+            } catch (error) {
+              reject(error);
+            }
+          }, 200);
+        } catch (error) {
+          reject(error);
+        }    
+      }, 300);      
     });
   });
 


### PR DESCRIPTION
- When the close function is called it will (p)unsubscribe from the channels it (p)subscribed to in the constructor.
- Added a test to verify that channels are being unsubscribed from when close is called.

This is implemented in conjunction with https://github.com/socketio/socket.io/pull/4602 to fix https://github.com/socketio/socket.io-redis-adapter/issues/480.