### PR TITLE
Add friendlyErrorHadler cleanup to prevent memory leak

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -106,6 +106,7 @@ export class RedisAdapter extends Adapter {
   private requests: Map<string, Request> = new Map();
   private ackRequests: Map<string, AckRequest> = new Map();
   private redisListeners: Map<string, Function> = new Map();
+  private readonly friendlyErrorHandler: () => void;
 
   /**
    * Adapter constructor.
@@ -182,16 +183,13 @@ export class RedisAdapter extends Adapter {
       );
     }
 
-    const registerFriendlyErrorHandler = (redisClient) => {
-      redisClient.on("error", () => {
-        if (redisClient.listenerCount("error") === 1) {
-          console.warn("missing 'error' handler on this Redis client");
-        }
-      });
+    this.friendlyErrorHandler = function () {
+      if (this.listenerCount("error") === 1) {
+        console.warn("missing 'error' handler on this Redis client");
+      }
     };
-
-    registerFriendlyErrorHandler(this.pubClient);
-    registerFriendlyErrorHandler(this.subClient);
+    this.pubClient.on("error", this.friendlyErrorHandler);
+    this.subClient.on("error", this.friendlyErrorHandler);
   }
 
   /**
@@ -980,5 +978,8 @@ export class RedisAdapter extends Adapter {
         this.redisListeners.get("messageBuffer")
       );
     }
+
+    this.pubClient.off("error", this.friendlyErrorHandler);
+    this.subClient.off("error", this.friendlyErrorHandler);
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@socket.io/redis-adapter",
-  "version": "8.0.1",
+  "version": "8.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@socket.io/redis-adapter",
-      "version": "8.0.1",
+      "version": "8.1.0",
       "license": "MIT",
       "dependencies": {
         "debug": "~4.3.1",


### PR DESCRIPTION
`registerFriendlyErrorHandler` method adds a listener on pub and sub client. Let's remove it in `close()`