### PR TITLE
Add disablePatternSubscriptions option

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,11 +13,14 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "test": "npm run format:check && tsc && npm run test:default && npm run test:redis-v4-specific-channel && npm run test:redis-v3 && npm run test:ioredis",
+    "test": "npm run format:check && tsc && npm run test:default && npm run test:redis-v4-specific-channel && npm run test:redis-v3 && npm run test:ioredis && npm run test:redis-v4-disable-pattern-subs && npm run test:redis-v3-disable-pattern-subs && npm run test:ioredis-disable-pattern-subs",
     "test:default": "nyc mocha --bail --require ts-node/register test/*.ts",
     "test:redis-v4-specific-channel": "SPECIFIC_CHANNEL=1 npm run test:default",
     "test:redis-v3": "REDIS_CLIENT=redis-v3 npm run test:default",
     "test:ioredis": "REDIS_CLIENT=ioredis npm run test:default",
+    "test:redis-v4-disable-pattern-subs": "DISABLE_PATTERN_SUBS=1 npm run test:default",
+    "test:redis-v3-disable-pattern-subs": "REDIS_CLIENT=redis-v3 DISABLE_PATTERN_SUBS=1 npm run test:default",
+    "test:ioredis-disable-pattern-subs": "REDIS_CLIENT=ioredis DISABLE_PATTERN_SUBS=1 npm run test:default",
     "format:check": "prettier --parser typescript --check 'lib/**/*.ts' 'test/**/*.ts'",
     "format:fix": "prettier --parser typescript --write 'lib/**/*.ts' 'test/**/*.ts'",
     "prepack": "tsc"

--- a/test/specifics.ts
+++ b/test/specifics.ts
@@ -87,8 +87,13 @@ describe("specifics", () => {
 
           // Depending on the version of redis this may be 3 (redis < v5) or 1 (redis > v4)
           // Older versions subscribed multiple times on the same pattern. Newer versions only sub once.
-          expect(info.pubsub_patterns).to.be.greaterThan(0);
-          expect(info.pubsub_channels).to.eql(5); // 2 shared (request/response) + 3 unique for each namespace
+          if (process.env.DISABLE_PATTERN_SUBS) {
+            expect(info.pubsub_patterns).to.eql(0);
+            expect(info.pubsub_channels).to.eql(6); // 2 shared (request/response) + 4 unique for each namespace
+          } else {
+            expect(info.pubsub_patterns).to.be.greaterThan(0);
+            expect(info.pubsub_channels).to.eql(5); // 2 shared (request/response) + 3 unique for each namespace
+          }
 
           servers[0].of("/").adapter.close();
           servers[1].of("/").adapter.close();

--- a/test/util.ts
+++ b/test/util.ts
@@ -63,6 +63,9 @@ export function setup(adapterOptions: Partial<RedisAdapterOptions> = {}) {
       adapterOptions.publishOnSpecificResponseChannel =
         process.env.SPECIFIC_CHANNEL !== undefined;
 
+      adapterOptions.disablePatternSubscriptions =
+        process.env.DISABLE_PATTERN_SUBS !== undefined;
+
       const httpServer = createServer();
       const io = new Server(httpServer, {
         adapter: createAdapter(pubClient, subClient, adapterOptions),


### PR DESCRIPTION
Turning on this option will disable the use of redis pattern subscriptions for receiving messages. All messages will be received through regular subscriptions.

Added new test scripts for running against all the redis clients with the option enabled.