### PR TITLE
serverCount should have `return` in map function

### DIFF
--- a/lib/cluster-adapter.ts
+++ b/lib/cluster-adapter.ts
@@ -625,8 +625,9 @@ export abstract class ClusterAdapterWithHeartbeat extends ClusterAdapter {
   }
 
   override serverCount(): Promise<number> {
+    const now = Date.now();
     this.nodesMap.forEach((lastSeen, uid) => {
-      const nodeSeemsDown = Date.now() - lastSeen > this._opts.heartbeatTimeout;
+      const nodeSeemsDown = now - lastSeen > this._opts.heartbeatTimeout;
       if (nodeSeemsDown) {
         debug("node %s seems down", uid);
         this.nodesMap.delete(uid);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -908,7 +908,7 @@ export class RedisAdapter extends Adapter {
         )
       ).then((values) => {
         let numSub = 0;
-        values.map((value) => {
+        values.forEach((value) => {
           numSub += parseInt(value[1], 10);
         });
         return numSub;

--- a/lib/sharded-adapter.ts
+++ b/lib/sharded-adapter.ts
@@ -122,7 +122,7 @@ class ShardedRedisAdapter extends ClusterAdapter {
         })
       ).then((values) => {
         let numSub = 0;
-        values.map((value) => {
+        values.forEach((value) => {
           numSub += parseInt(value[1], 10);
         });
         return numSub;

--- a/lib/sharded-adapter.ts
+++ b/lib/sharded-adapter.ts
@@ -118,7 +118,7 @@ class ShardedRedisAdapter extends ClusterAdapter {
     ) {
       return Promise.all(
         this.pubClient.nodes().map((node) => {
-          node.sendCommand(["PUBSUB", "SHARDNUMSUB", this.channel]);
+          return node.sendCommand(["PUBSUB", "SHARDNUMSUB", this.channel]);
         })
       ).then((values) => {
         let numSub = 0;


### PR DESCRIPTION
- [fix: serverCount method should return result](https://github.com/socketio/socket.io-redis-adapter/pull/497/commits/1781819e142b95edf3f80709c381eb45b2f154a4)
- [perf: no need call Date.now() in loops](https://github.com/socketio/socket.io-redis-adapter/pull/497/commits/7882a58d91b5ba277fae495f7f4da840f6e3d3a3)
- [feat: use forEach instead map if no value return](https://github.com/socketio/socket.io-redis-adapter/pull/497/commits/f09bfc3958f3c15071bd5e68b7a2a6a9a1455520)