### PR TITLE
Redis adapter is not correctly cleaning up/unsubscribing topics when handling socketIO middleware errors

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -942,7 +942,7 @@ export class RedisAdapter extends Adapter {
     this.subClient.off("error", this.friendlyErrorHandler);
   }
   delAll(id: SocketId) {
-    // Call general adapter cleanup
+    // Call parent adapter cleanup
     super.delAll(id);
     // Unsubscribe from Redis topics
     this.close();

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,6 +1,6 @@
 import uid2 = require("uid2");
 import msgpack = require("notepack.io");
-import { Adapter, BroadcastOptions, Room } from "socket.io-adapter";
+import { Adapter, BroadcastOptions, Room, SocketId } from "socket.io-adapter";
 import { PUBSUB } from "./util";
 
 const debug = require("debug")("socket.io-redis");
@@ -940,6 +940,12 @@ export class RedisAdapter extends Adapter {
 
     this.pubClient.off("error", this.friendlyErrorHandler);
     this.subClient.off("error", this.friendlyErrorHandler);
+  }
+  delAll(id: SocketId) {
+    // Call general adapter cleanup
+    super.delAll(id);
+    // Unsubscribe from Redis topics
+    this.close();
   }
 }
 


### PR DESCRIPTION
hello, found a bug where redis adapter is not correctly cleaning up/unsubscribing topics when handling socketIO middleware errors:

- When we call `next(new Error('Foo')` in a socketIO middleware (as suggested [here](https://socket.io/docs/v3/middlewares/#registering-a-middleware)), socketIO lib calls _cleanup on error [here](https://github.com/socketio/socket.io/blob/main/lib/namespace.ts#L333)
- (note that, at this point, redis-adapter is already subscribed to topics in Redis)
- [_cleanup](https://github.com/socketio/socket.io/blob/main/lib/socket.ts#L773) implementation calls `leaveAll`, which is [here](https://github.com/socketio/socket.io/blob/main/lib/socket.ts#L589) and which calls adapter.delAll
- socketIO adapter interface defines `delAll`  [here](https://github.com/socketio/socket.io-adapter/blob/main/lib/index.ts#L137) (it calls `this._del` in a loop)
- [redis adapter](https://github.com/socketio/socket.io-redis-adapter/blob/main/lib/index.ts) however does not override/extend this method with custom behaviour, which, i think, should clean up Redis subscriptions

This causes leaking subscriptions on Redis servers of clients that are long gone.

Added a draft of what seems to fix the problem, though not sure whether this is the most correct approach, and also I don't know how to test this 🙈.