### PR TITLE
fix(sharded): expectedResponseCount in fetchSockets()

### DIFF
--- a/lib/cluster-adapter.ts
+++ b/lib/cluster-adapter.ts
@@ -436,7 +436,7 @@ export abstract class ClusterAdapter extends Adapter {
     ]);
     const expectedResponseCount = serverCount - 1;
 
-    if (opts.flags?.local || expectedResponseCount === 0) {
+    if (opts.flags?.local || expectedResponseCount <= 0) {
       return localSockets;
     }
 


### PR DESCRIPTION
If `fetchSockets()` is called shortly after the adapter was initialized, the server count may still return `0`, causing this to fail with `timeout reached: only 0 responses received out of -1`.

The problem is [handled correctly](https://github.com/socketio/socket.io-redis-adapter/blob/4c372a8f73b32ae19dea69b938e441d3dac97e52/lib/index.ts#L739) in the regular adapter, so using the same approach here.