### PR TITLE
fix(sharded): private room broadcast in dynamic mode

### DIFF
--- a/lib/sharded-adapter.ts
+++ b/lib/sharded-adapter.ts
@@ -128,7 +128,8 @@ class ShardedRedisAdapter extends ClusterAdapter {
       this.opts.subscriptionMode === "dynamic" &&
       message.type === MessageType.BROADCAST &&
       message.data.requestId === undefined &&
-      message.data.opts.rooms.length === 1;
+      message.data.opts.rooms.length === 1 &&
+      !message.data.opts.flags.expectSingleResponse;
     if (useDynamicChannel) {
       return this.dynamicChannel(message.data.opts.rooms[0]);
     } else {

--- a/lib/sharded-adapter.ts
+++ b/lib/sharded-adapter.ts
@@ -5,6 +5,10 @@ import debugModule from "debug";
 
 const debug = debugModule("socket.io-redis");
 
+function looksLikeASocketId(room: any) {
+  return typeof room === "string" && room.length === 20;
+}
+
 export interface ShardedRedisAdapterOptions {
   /**
    * The prefix for the Redis Pub/Sub channels.
@@ -129,7 +133,7 @@ class ShardedRedisAdapter extends ClusterAdapter {
       message.type === MessageType.BROADCAST &&
       message.data.requestId === undefined &&
       message.data.opts.rooms.length === 1 &&
-      !message.data.opts.flags.expectSingleResponse;
+      !looksLikeASocketId(message.data.opts.rooms[0]);
     if (useDynamicChannel) {
       return this.dynamicChannel(message.data.opts.rooms[0]);
     } else {

--- a/test/index.ts
+++ b/test/index.ts
@@ -110,6 +110,14 @@ export function testSuite(createAdapter: any) {
         servers[0].local.emit("test");
       });
 
+      it("broadcasts to a single client", (done) => {
+        clientSockets[0].on("test", shouldNotHappen(done));
+        clientSockets[1].on("test", () => done());
+        clientSockets[2].on("test", shouldNotHappen(done));
+
+        servers[0].to(serverSockets[1].id).emit("test");
+      });
+
       it("broadcasts with multiple acknowledgements", (done) => {
         clientSockets[0].on("test", (cb) => cb(1));
         clientSockets[1].on("test", (cb) => cb(2));

--- a/test/specifics.ts
+++ b/test/specifics.ts
@@ -1,7 +1,7 @@
 import type { Server, Socket as ServerSocket } from "socket.io";
 import type { Socket as ClientSocket } from "socket.io-client";
 import expect = require("expect.js");
-import { shouldNotHappen, setup } from "./util";
+import { shouldNotHappen, setup, times } from "./util";
 import type { RedisAdapter } from "../lib";
 
 export function testSuite(
@@ -39,6 +39,20 @@ export function testSuite(
 
         // @ts-ignore
         servers[1].to(123).emit("test");
+      });
+
+      it("broadcasts to the socket's private room", function (done) {
+        const partialDone = times(servers.length * clientSockets.length, done);
+
+        clientSockets.forEach((clientSocket) => {
+          clientSocket.on("test", () => partialDone());
+        });
+
+        servers.forEach((server) => {
+          server.fetchSockets().then((sockets) => {
+            sockets.forEach((socket) => socket.emit("test"));
+          });
+        });
       });
     });
 

--- a/test/specifics.ts
+++ b/test/specifics.ts
@@ -1,7 +1,7 @@
 import type { Server, Socket as ServerSocket } from "socket.io";
 import type { Socket as ClientSocket } from "socket.io-client";
 import expect = require("expect.js");
-import { shouldNotHappen, setup, times } from "./util";
+import { shouldNotHappen, setup } from "./util";
 import type { RedisAdapter } from "../lib";
 
 export function testSuite(
@@ -39,20 +39,6 @@ export function testSuite(
 
         // @ts-ignore
         servers[1].to(123).emit("test");
-      });
-
-      it("broadcasts to the socket's private room", function (done) {
-        const partialDone = times(servers.length * clientSockets.length, done);
-
-        clientSockets.forEach((clientSocket) => {
-          clientSocket.on("test", () => partialDone());
-        });
-
-        servers.forEach((server) => {
-          server.fetchSockets().then((sockets) => {
-            sockets.forEach((socket) => socket.emit("test"));
-          });
-        });
       });
     });
 


### PR DESCRIPTION
Fixes #524 by adding a check for `expectSingleResponse` flag, which is added for `RemoteSocket` instances [here](https://github.com/socketio/socket.io/blob/54dabe5bffeb705fd006729725dd2fa194f70ecf/lib/broadcast-operator.ts#L491). I couldn't find any documentation about that flag, but it seems to be the only way of identifying this case and it does fix the problem.