### PR TITLE
feat(sharded): add an option for dynamic private channels

### DIFF
--- a/test/test-runner.ts
+++ b/test/test-runner.ts
@@ -175,6 +175,28 @@ describe("@socket.io/redis-adapter", () => {
       true
     ));
 
+  describe("[sharded] redis@4 standalone (dynamic subscription mode & dynamic private channels)", () =>
+    testSuite(
+      async () => {
+        const pubClient = createClient();
+        const subClient = pubClient.duplicate();
+
+        await Promise.all([pubClient.connect(), subClient.connect()]);
+
+        return [
+          createShardedAdapter(pubClient, subClient, {
+            subscriptionMode: "dynamic-private",
+          }),
+          () => {
+            pubClient.disconnect();
+            subClient.disconnect();
+          },
+        ];
+      },
+      "redis@4",
+      true
+    ));
+
   describe("[sharded] redis@4 standalone (static subscription mode)", () =>
     testSuite(
       async () => {


### PR DESCRIPTION
As an alternative solution for #524, this:
 - adds a new option `dynamicPrivateChannels`, which allows creating separate channels even for private rooms; defaults to `false` so there's no change in default behavior,
 - includes the fix from #525 which is needed when the option is set to `false`