### PR TITLE
feat: SERVER_SIDE_EMIT support publishOnSpecificResponseChannel

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -412,8 +412,11 @@ export class RedisAdapter extends Adapter {
           }
           called = true;
           debug("calling acknowledgement with %j", arg);
+          const responseChannel = this.publishOnSpecificResponseChannel
+            ? `${this.responseChannel}${request.uid}#`
+            : this.responseChannel;
           this.pubClient.publish(
-            this.responseChannel,
+            responseChannel,
             JSON.stringify({
               type: RequestType.SERVER_SIDE_EMIT,
               requestId: request.requestId,


### PR DESCRIPTION
related: https://github.com/socketio/socket.io-redis-adapter/issues/407

the `publishOnSpecificResponseChannel` config should also improve [namespace.serverSideEmit()](https://socket.io/docs/v4/server-api/#namespaceserversideemiteventname-args)

code change similar to: https://github.com/socketio/socket.io-redis-adapter/commit/f66de114a4581b692da759015def0373c619aab7#diff-d5a4b3a0309f2337144861084c1014523cced561eb722cb9684c63f5e41e0567R391-R395

GitHub CI test passed: https://github.com/dr-js/socket.io-redis-adapter/actions/runs/8614387767