### PR TITLE
refactor: Remove redundant condition `this.ackRequests.has(requestId)`

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -526,7 +526,7 @@ export class RedisAdapter extends Adapter {
 
     if (
       !requestId ||
-      !(this.requests.has(requestId) || this.ackRequests.has(requestId))
+      !this.requests.has(requestId)
     ) {
       debug("ignoring unknown request");
       return;


### PR DESCRIPTION
fixes socketio/socket.io-redis-adapter#549