### PR TITLE
fix: update incorrect comment for publishOnSpecificResponseChannel

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -59,8 +59,8 @@ export interface RedisAdapterOptions {
   /**
    * Whether to publish a response to the channel specific to the requesting node.
    *
-   * - if true, the response will be published to `${key}-request#${nsp}#${uid}#`
-   * - if false, the response will be published to `${key}-request#${nsp}#`
+   * - if true, the response will be published to `${key}-response#${nsp}#${uid}#`
+   * - if false, the response will be published to `${key}-response#${nsp}#`
    *
    * This option currently defaults to false for backward compatibility, but will be set to true in the next major
    * release.


### PR DESCRIPTION
The details are in the existing issue: [#554](https://github.com/socketio/socket.io-redis-adapter/issues/554)